### PR TITLE
python 3.4: TypeError: required field "arg" missing from arg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+0.0.10
+------
+
+- add compatibility with python3.4
+
 0.0.9
 -----
 

--- a/black_magic/compat.py
+++ b/black_magic/compat.py
@@ -10,8 +10,12 @@ both languages.
 __all__ = ['signature', 'Signature',
            'getfullargspec', 'FullArgSpec',
            'ast_arg',
+           'ast_set_special_arg',
            'exec_compat',
            'is_identifier']
+
+
+import sys
 
 
 # Python2 has no annotations and kwonly arguments, therefore we need to
@@ -53,6 +57,16 @@ except ImportError:
     import ast
     def ast_arg(arg, annotation, **kwargs):
         return ast.Name(id=arg, ctx=ast.Param(), **kwargs)
+
+
+# Python3.4 uses an ast.arg for ast.arguments.kwarg(annotation).
+if sys.version_info >= (3, 4):
+    def ast_set_special_arg(kind, arguments, name, annotation):
+        setattr(arguments, kind, ast_arg(arg=name, annotation=annotation))
+else:
+    def ast_set_special_arg(kind, arguments, name, annotation):
+        setattr(arguments, kind, name)
+        setattr(arguments, kind + 'annotation', annotation)
 
 
 def exec_compat(expression, globals, locals=None):

--- a/black_magic/decorator.py
+++ b/black_magic/decorator.py
@@ -152,15 +152,15 @@ class ASTorator(object):
 
             # varargs
             elif param.kind == param.VAR_POSITIONAL:
-                sig.vararg = name
-                sig.varargannotation = attr(param, 'annotation')
+                compat.ast_set_special_arg('vararg', sig,
+                                           name, attr(param, 'annotation'))
                 call.starargs = ast.Name(id=name, ctx=ast.Load(),
                                          lineno=1, col_offset=0)
 
             # kwargs
             elif param.kind == param.VAR_KEYWORD:
-                sig.kwarg = name
-                sig.kwargannotation = attr(param, 'annotation')
+                compat.ast_set_special_arg('kwarg', sig,
+                                           name, attr(param, 'annotation'))
                 call.kwargs = ast.Name(id=name, ctx=ast.Load(),
                                        lineno=1, col_offset=0)
 


### PR DESCRIPTION
``` python
from black_magic.decorator import wraps
def foo(*a):
    pass
wraps(foo)(foo)
```

gives: 

```
Traceback (most recent call last):
  File "k.py", line 7, in <module>
    wraps(foo)(foo)
  File "/home/thomas/src/project/black_magic/black_magic/decorator.py", line 296, in <lambda>
    return lambda wrapper, signature=signature: wraps(function, wrapper, signature)
  File "/home/thomas/src/project/black_magic/black_magic/decorator.py", line 300, in wraps
    return ASTorator.from_function(function, signature=signature)(wrapper)
  File "/home/thomas/src/project/black_magic/black_magic/decorator.py", line 237, in decorate
    code = compile(expr, filename, 'exec')
TypeError: required field "arg" missing from arg
```
